### PR TITLE
get_magic_quotes_gpc() fix

### DIFF
--- a/src/Evp/Notification/Util.php
+++ b/src/Evp/Notification/Util.php
@@ -43,10 +43,18 @@ class Evp_Notification_Util
     {
         $params = array();
         parse_str($query, $params);
-        if (get_magic_quotes_gpc()) {
+        if ($this->checkMagicQuotesOption()) {
             $params = $this->stripSlashesRecursively($params);
         }
         return $params;
+    }
+
+    private function checkMagicQuotesOption() {
+        if (version_compare(PHP_VERSION, '5.4.0') >= 0) {
+            return false;
+        } else {
+            return get_magic_quotes_gpc();
+        }
     }
 
     /**


### PR DESCRIPTION
Fix, so that the deprecation warning wouldn't be shown with higher PHP versions.